### PR TITLE
Add http-get to the test script in order to work around webpack limit…

### DIFF
--- a/.github/workflows/github-actions-init.yml
+++ b/.github/workflows/github-actions-init.yml
@@ -15,4 +15,4 @@ jobs:
       # - name: Start Server
       #   run: npm start
       - name: Cypress run
-        run: test
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eject": "react-scripts eject",
     "cypress": "./node_modules/.bin/cypress open",
     "cy:run": "cypress run",
-    "test": "start-server-and-test start http-get://localhost:3000 cy:run"
+    "test": "start-server-and-test start http://localhost:3000 cy:run"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "start-server-and-test start http://localhost:3000 cypress",
     "eject": "react-scripts eject",
-    "cypress": "./node_modules/.bin/cypress open"
+    "cypress": "./node_modules/.bin/cypress open",
+    "cy:run": "cypress run",
+    "test": "start-server-and-test start http-get://localhost:3000 cy:run"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
…ations

### Feature? / Refactor? / Fix?
Refactor


### What Changed and Why?
Added a -get to the start-server-and-test script command in order to work around Webpack's limitations.


### Any Resources that helped solve it?
https://docs.cypress.io/guides/continuous-integration/introduction#Boot-your-server (command f for http-get)


### Notes Going Forward?
Not at the moment!